### PR TITLE
Clicking on the "About Us" button on mobile leads to a 404 error page

### DIFF
--- a/content/pages/about_us.md
+++ b/content/pages/about_us.md
@@ -1,0 +1,20 @@
+---
+blocks:
+  - quote: About us
+    color: tint
+    _template: testimonial
+  - items:
+      - icon:
+          color: ''
+          style: float
+          name: user
+        title: Our Team
+        link: /team
+      - icon:
+          color: ''
+          style: float
+          name: world
+        title: Join Us
+        link: /positions
+    _template: features
+---


### PR DESCRIPTION
Fixes mobile bug where clicking on "About Us" button leads to 404 error. Added new `about_us.md` file with team and join us section, similar to the `resources.md` file.